### PR TITLE
made converting bankswitch-name ti -type case insensitive, as used by command line argument -bs=

### DIFF
--- a/BSType.hxx
+++ b/BSType.hxx
@@ -103,6 +103,9 @@ class Bankswitch
     // Convert string to BSType enum
     static BSType nameToType(const string& name)
     {
+      std::string upper( name );
+      for(int i = 0, namelen = name.length(); i < namelen; ++i)
+        upper[i] = ::toupper( upper[i] );
       for(int i = 0; i < int(BSType::NumSchemes); ++i)
         if(BSList[i].name == name)
           return BSType(i);


### PR DESCRIPTION
A was very annoyed when finding out why
harmonycart -bs=custom mycart_with_arm.bin
didn't work... it had to be "-bs=CUSTOM" instead.

To make sure, this doesn't happen again, here's my suggestion for a fix.