### PR TITLE
Added new option: F4 compression bank 0 skip

### DIFF
--- a/Cart.cxx
+++ b/Cart.cxx
@@ -33,7 +33,8 @@ Cart::Cart()
   : myDetectedDevice(0),
     myRetry(1),
     myOscillator("10000"),
-    myLog(&cout)
+    myLog(&cout),
+    myF4FirstCompressionBank(0)
 {
   myProgress.setWindowModality(Qt::WindowModal);
   myProgress.setWindowIcon(QPixmap(":icons/pics/appicon.png"));
@@ -44,6 +45,12 @@ Cart::Cart()
 void Cart::setLogger(ostream* out)
 {
   myLog = out;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Cart::skipF4CompressionOnBank0(bool skip)
+{
+   myF4FirstCompressionBank = skip ? 1 : 0;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -200,7 +207,7 @@ string Cart::downloadROM(SerialPort& port, const string& armpath,
       //   01235674  01234675  01234576  01234567
 
       uInt32 i;
-      for(i = 0; i < 8; ++i) // i = bank to go last
+      for(i = myF4FirstCompressionBank; i < 8; ++i) // i = bank to go last
       {
         uInt8* ptr = binary_ptr;
         for(uInt32 h = 0; h < 8; ++h)

--- a/Cart.hxx
+++ b/Cart.hxx
@@ -69,6 +69,14 @@ class Cart
     /** Set number of write retries before bailing out. */
     void setRetry(int retry) { myRetry = retry + 1; }
 
+    /**
+      On F4 (32K) bankswitching, when the first bank is compressed, the
+      cartridge starts in bank 1. This can cause problems with some ROMs.
+      This option will allow to leave out bank 0 when searching for the
+      first compressable bank.
+    */
+    void skipF4CompressionOnBank0(bool skip);
+
   private:
     enum TARGET           { NXP_ARM, ANALOG_DEVICES_ARM };
     enum TARGET_MODE      { PROGRAM_MODE, RUN_MODE      };
@@ -149,6 +157,7 @@ class Cart
     uInt32   myRetry;
     string   myOscillator;
     ostream* myLog;
+    uInt32   myF4FirstCompressionBank;
 
     QProgressDialog myProgress;
 

--- a/HarmonyCartWindow.cxx
+++ b/HarmonyCartWindow.cxx
@@ -116,6 +116,7 @@ void HarmonyCartWindow::setupConnections()
   group->addAction(ui->actRetry3);
   connect(group, SIGNAL(triggered(QAction*)), this, SLOT(slotRetry(QAction*)));
   connect(ui->actShowLogAfterDownload, SIGNAL(toggled(bool)), this, SLOT(slotShowLog(bool)));
+  connect(ui->actF4CompressionNoBank0, SIGNAL(toggled(bool)), this, SLOT(slotF4CompressionBank0Skip(bool)));
 
   // Help menu
   connect(ui->actAbout, SIGNAL(triggered()), this, SLOT(slotAbout()));
@@ -185,6 +186,7 @@ void HarmonyCartWindow::readSettings()
       default: ui->actRetry0->setChecked(true);  break;
     }
     ui->actShowLogAfterDownload->setChecked(s.value("showlog", false).toBool());
+    ui->actF4CompressionNoBank0->setChecked(s.value("f4compressbank0skip", false).toBool());
     ui->actAutoDownFileSelect->setChecked(s.value("autodownload", false).toBool());
     ui->actAutoVerifyDownload->setChecked(s.value("autoverify", false).toBool());
     int activetab = s.value("activetab", 0).toInt();
@@ -267,6 +269,7 @@ void HarmonyCartWindow::closeEvent(QCloseEvent* event)
     s.setValue("autodownload", ui->actAutoDownFileSelect->isChecked());
     s.setValue("autoverify", ui->actAutoVerifyDownload->isChecked());
     s.setValue("showlog", ui->actShowLogAfterDownload->isChecked());
+    s.setValue("f4compressbank0skip", ui->actF4CompressionNoBank0->isChecked());
     s.setValue("activetab", ui->tabWidget->currentIndex());
   s.endGroup();
 
@@ -656,6 +659,12 @@ void HarmonyCartWindow::slotShowLog(bool checked)
     myCart.setLogger(&myLog);
   else
     myCart.setLogger(&cout);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void HarmonyCartWindow::slotF4CompressionBank0Skip(bool checked)
+{
+  myCart.skipF4CompressionOnBank0(checked);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/HarmonyCartWindow.hxx
+++ b/HarmonyCartWindow.hxx
@@ -83,6 +83,7 @@ Q_OBJECT
     void slotQPButtonClicked(QAbstractButton* b);
     void slotBSTypeChanged(int id);
     void slotShowLog(bool checked);
+    void slotF4CompressionBank0Skip(bool checked);
     void slotShowDefaultMsg();
 
     void slotSelectEEPROM();

--- a/harmonycartwindow.ui
+++ b/harmonycartwindow.ui
@@ -1205,6 +1205,7 @@ Left-click to use the chosen ROM.</string>
     <addaction name="actAutoDownFileSelect"/>
     <addaction name="actAutoVerifyDownload"/>
     <addaction name="actShowLogAfterDownload"/>
+    <addaction name="actF4CompressionNoBank0"/>
     <addaction name="menuRetryCount"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -1368,6 +1369,14 @@ Left-click to use the chosen ROM.</string>
    </property>
    <property name="text">
     <string>Show log after download</string>
+   </property>
+  </action>
+  <action name="actF4CompressionNoBank0">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Skip bank 0 compression on F4</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
For F4 bankswitching on bank has to be compressed. If bank 0 is chosen to
be compressed, this will not bank selected after power on. The PLD boards
always start on bank 0. At least one ROM (Triptych) requires this.
Selection this option will make sure that the first bank is never
compressed.

There now is a new entry in the "Options" submenu.